### PR TITLE
Added 'remove' command

### DIFF
--- a/src/main/java/me/jadenPete/OpenPaintings/Commands.java
+++ b/src/main/java/me/jadenPete/OpenPaintings/Commands.java
@@ -39,8 +39,10 @@ public class Commands implements CommandExecutor {
 			
 			if(args.length == 2 && args[0].equalsIgnoreCase("select")) { //select a painting if given the proper arguments
 			  Util.selectPainting(player, args);
-			} else if(args.length == 1 && args[0].equalsIgnoreCase("cancel")) { //cancel the placement of a painting when given the proper arguments
-			  Util.cancelSelection(player);
+			} else if(args.length == 1 && args[0].equalsIgnoreCase("remove")) { //cancel the placement of a painting when given the proper arguments
+			  Util.removeSelection(player);
+			} else if(args.length == 1 && args[0].equalsIgnoreCase("cancel")) {
+			  Util.cancelSelections(player);
 			} else if(args.length == 1 && args[0].equalsIgnoreCase("list")) { //list the painting options when given the proper arguments
 			  Util.listPaintings(player);
 			} else {

--- a/src/main/java/me/jadenPete/OpenPaintings/Events.java
+++ b/src/main/java/me/jadenPete/OpenPaintings/Events.java
@@ -54,6 +54,6 @@ public class Events implements Listener {
 	// When a player disconnects.
 	@EventHandler
 	public void onPlayerQuit(PlayerQuitEvent event) {
-		Util.cancelAllSelections(event.getPlayer());
+		Util.cancelSelections(event.getPlayer());
 	}
 }

--- a/src/main/java/me/jadenPete/OpenPaintings/Util.java
+++ b/src/main/java/me/jadenPete/OpenPaintings/Util.java
@@ -92,13 +92,13 @@ public class Util {
 	}
 	
 	// Remove a player's selection.
-	public static void cancelSelection(Player player) {
+	public static void removeSelection(Player player) {
 	  
 	  String playerName = player.getName();
 	  
 	  if(selections.containsKey(playerName) && selections.get(playerName).hasNext()) {
 	    selections.get(playerName).discardNewest();
-	    player.sendMessage(config.getString("messages.cancel"));
+	    player.sendMessage(config.getString("messages.remove"));
 	  } else {
 	    player.sendMessage(config.getString("messages.cancel-error"));
 	  }
@@ -106,8 +106,16 @@ public class Util {
 	}
 	
 	// Remove the player from the database.
-	public static void cancelAllSelections(Player player) {
-	  selections.remove(player.getName());
+	public static void cancelSelections(Player player) {
+	  
+	  String playerName = player.getName();
+	  
+	  if(selections.containsKey(playerName)) {
+	    selections.remove(player.getName());
+	    player.sendMessage(config.getString("messages.cancel"));
+	  } else {
+	    player.sendMessage(config.getString("messages.cancel-error"));
+	  }
 	}
 	
 	// Provide a player with a list of valid paintings.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,7 +2,8 @@ messages:
   select: "§aPainting selected."
   place: "§aPainting placed."
   
-  cancel: "§cSelection canceled."
+  remove: "§cPrevious selection canceled."
+  cancel: "§cAll selections canceled."
   list: "§cAvailable paintings: §6ALBAN, AZTEC, AZTEC2, BOMB, BURNINGSKULL, BUST, COURBET, CREEBET, DONKEYKONG, FIGHTERS, GRAHAM, KEBAB, MATCH, PIGSCENE, PLANT, POINTER, POOL, SEA, SKELETON, SKULL_AND_ROSES, STAGE, SUNSET, VOID, WANDERER, WASTELAND, WITHER "
   
   place-error: "§cThat painting is too big."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,7 @@ commands:
       §8§m----------------------------------§r
       §8(§5Paintings§8)§e Help Documentation
       §8(§5Paintings§8)§6   /painting select <name>
+      §8(§5Paintings§8)§6   /painting remove
       §8(§5Paintings§8)§6   /painting cancel
       §8(§5Paintings§8)§6   /painting list
       §8§m----------------------------------§r


### PR DESCRIPTION
Now, **/painting cancel** removes all selections for a particular player and **/painting remove** simply removes the most recent selection. The player is able to make multiple selections before placing the paintings consecutively. Also, the appropriate messages have been added to the default configuration file.